### PR TITLE
Measure subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class Demo extends \util\profiling\Measurable {
 Running:
 
 ```sh
-$ xp util.profiling.Measure Demo -n 1000000
+$ xp measure -1000000 Demo
 strpos(""): 1000000 iteration(s), 0.534 seconds, result= -1
 strpos("."): 1000000 iteration(s), 0.527 seconds, result= 0
 strpos(".a"): 1000000 iteration(s), 0.523 seconds, result= 0

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ class Demo extends \util\profiling\Measurable {
 Running:
 
 ```sh
-$ xp util.profiling.Measure Demo -n 1000000
-strpos: 1000000 iteration(s), 0.514 seconds, result= 3
-strcspn: 1000000 iteration(s), 0.522 seconds, result= 3
+$ xp measure -1000000 Demo
+strpos: 1000000 iteration(s), 0.308 seconds, result= 3
+strcspn: 1000000 iteration(s), 0.350 seconds, result= 3
 ```
 
 Permutation

--- a/bin/xp.xp-forge.measure
+++ b/bin/xp.xp-forge.measure
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+This must be run from within an XP runner

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "require-dev" : {
     "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
+  "bin": ["bin/xp.xp-forge.measure"],
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]
   }

--- a/src/main/php/util/profiling/Measure.class.php
+++ b/src/main/php/util/profiling/Measure.class.php
@@ -1,66 +1,10 @@
 <?php namespace util\profiling;
 
-use lang\XPClass;
-use lang\IllegalArgumentException;
-use util\cmd\Console;
-use util\Objects;
-
+/** @deprecated - use xp.measure.Runner instead */
 class Measure {
 
-  /**
-   * Performs measurement
-   *
-   * @param  util.profiling.Measurement $m
-   */
-  public function run($m) {
-    $m->perform(newinstance(Run::class, [], [
-      'before' => function($iteration) { Console::write($iteration->name(), ': '); },
-      'after'  => function($result) {
-        Console::writeLinef(
-          '%d iteration(s), %.3f seconds, result= %s',
-          $result->iteration()->times(),
-          $result->elapsed(),
-          Objects::stringOf($result->result())
-        );
-      }
-    ]));
-  }
-
-  /**
-   * Returns a given argument
-   *
-   * @param  string[] $args The source
-   * @param  int $i The offset
-   * @param  string $arg The name
-   * @return string
-   * @throws lang.IllegalArgumentException
-   */
-  protected static function arg($args, $i, $arg) {
-    if (!isset($args[$i])) {
-      throw new IllegalArgumentException('Missing argument for '.$arg);
-    }
-    return $args[$i];
-  }
-
-  /**
-   * Main entry point
-   *
-   * @param  string[] $args
-   * @return int
-   */
+  /** @return int */
   public static function main(array $args) {
-    $m= new Measurement();
-    for ($i= 0, $s= sizeof($args); $i < $s; $i++) {
-      if ('-n' === $args[$i]) {
-        $m->iterating((int)self::arg($args, ++$i, '-n'));
-      } else if ('-' === $args[$i]{0} && is_numeric($args[$i])) {
-        $m->iterating((int)substr($args[$i], 1));
-      } else {
-        $m->measuring(XPClass::forName($args[$i]));
-      }
-    }
-
-    (new self())->run($m);
-    return 0;
+    return \xp\measure\Runner::main($args);
   }
 }

--- a/src/main/php/xp/measure/Runner.class.php
+++ b/src/main/php/xp/measure/Runner.class.php
@@ -1,0 +1,81 @@
+<?php namespace xp\measure;
+
+use util\profiling\Run;
+use util\profiling\Measurement;
+use lang\XPClass;
+use lang\IllegalArgumentException;
+use util\cmd\Console;
+use util\Objects;
+
+/**
+ * Measures util.profiling.Measurable instances
+ * ====================================================================
+ *
+ * - Runs measurements in CheckForToString class
+ *   ```sh
+ *   $ xp measure CheckForToString
+ *   ```
+ * - Sets number of iterations to 10000 (defaults to 1)
+ *   ```sh
+ *   $ xp measure -10000 CheckForToString
+ *   ```
+ */
+class Runner {
+
+  /**
+   * Performs measurement
+   *
+   * @param  util.profiling.Measurement $m
+   */
+  public function run($m) {
+    $m->perform(newinstance(Run::class, [], [
+      'before' => function($iteration) { Console::write($iteration->name(), ': '); },
+      'after'  => function($result) {
+        Console::writeLinef(
+          '%d iteration(s), %.3f seconds, result= %s',
+          $result->iteration()->times(),
+          $result->elapsed(),
+          Objects::stringOf($result->result())
+        );
+      }
+    ]));
+  }
+
+  /**
+   * Returns a given argument
+   *
+   * @param  string[] $args The source
+   * @param  int $i The offset
+   * @param  string $arg The name
+   * @return string
+   * @throws lang.IllegalArgumentException
+   */
+  protected static function arg($args, $i, $arg) {
+    if (!isset($args[$i])) {
+      throw new IllegalArgumentException('Missing argument for '.$arg);
+    }
+    return $args[$i];
+  }
+
+  /**
+   * Main entry point
+   *
+   * @param  string[] $args
+   * @return int
+   */
+  public static function main(array $args) {
+    $m= new Measurement();
+    for ($i= 0, $s= sizeof($args); $i < $s; $i++) {
+      if ('-n' === $args[$i]) {
+        $m->iterating((int)self::arg($args, ++$i, '-n'));
+      } else if ('-' === $args[$i]{0} && is_numeric($args[$i])) {
+        $m->iterating((int)substr($args[$i], 1));
+      } else {
+        $m->measuring(XPClass::forName($args[$i]));
+      }
+    }
+
+    (new self())->run($m);
+    return 0;
+  }
+}


### PR DESCRIPTION
This pull request adds a "measure" subcommand. Instead of referencing the class by typing `xp util.profiling.Measure -1000000 Demo`, the command line is now easier:

```bash
$ xp measure -1000000 Demo
strpos: 1000000 iteration(s), 0.308 seconds, result= 3
strcspn: 1000000 iteration(s), 0.350 seconds, result= 3
```

*:warning: The class `util.profiling.Measure` continues to exist but is deprecated*